### PR TITLE
Use ubuntu-22.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-21.04"
+  config.vm.box = "bento/ubuntu-22.04"
   config.vm.box_check_update = true
 
   config.vm.network "private_network", ip: "192.168.56.0"


### PR DESCRIPTION
The repositories for ubuntu-21.04 are not available anymore and return 404 errors. We with @briannaromasky tested it with ubuntu-22.04, and the installation and startup were successful.